### PR TITLE
Add TF 13.x and AWS Provider 3.x Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module "kinesis_firehose" {
 | cloudwatch_log_retention | Length in days to keep CloudWatch logs of Kinesis Firehose | integer | `30` | no |
 | log_stream_name | Name of the CloudWatch log stream for Kinesis Firehose CloudWatch log group | string | `SplunkDelivery` | no |
 | s3_bucket_name  | Name of the s3 bucket Kinesis Firehose uses for backups | string | `kinesis-firehose-to-splunk` | yes |
+| s3_bucket_block_public_access_enabled | If statement if you would like to add the aws_s3_bucket_public_access_block terraform resource on s3 bucket Kinesis Firehose uses for backups. Set to 1 for enabled. | integer | 0 | no | 
 | s3_compression_format | The compression format for what the Kinesis Firehose puts in the s3 bucket | string | `GZIP` | no |
 | kinesis_firehose_lambda_role_name | Name of IAM Role for Lambda function that transforms CloudWatch data for Kinesis Firehose into Splunk compatible format | string | `KinesisFirehoseToLambaRole` | no |
 | lambda_iam_policy_name | Name of the IAM policy that is attached to the IAM Role for the lambda transform function | string | `Kinesis-Firehose-to-Splunk-Policy` | no |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ module "kinesis_firehose" {
   hec_token = "<KMS_encrypted_token>"
   kms_key_arn = "arn:aws:kms:us-east-1:<aws_account_number:key/<kms_key_id>"
   hec_url = "<Splunk_Kinesis_ingest_URL>"
+  s3_bucket_name = "mybucketname"
 }
 
 ```
@@ -31,7 +32,7 @@ module "kinesis_firehose" {
 | region | The region of AWS you want to work in, such as us-west-2 or us-east-1 | string | - | yes |
 | arn_cloudwatch_logs_to_ship | arn of the CloudWatch Log Group that you want to ship to Splunk. | string | - | yes |
 | name_cloudwatch_logs_to_ship | name of the CloudWatch Log Group that you want to ship to Splunk. | string | - | yes |
-| hec_token | Splunk security token needed to submit data to Splunk vai HEC URL. Encyrpted with [this](https://www.terraform.io/docs/providers/aws/d/kms_secrets.html#example-usage) procedure using a KMS key of your choice. | string | - | yes |
+| hec_token | Splunk security token needed to submit data to Splunk vai HEC URL. Encyrpted with [this](https://www.terraform.io/docs/providers/aws/d/kms_secrets.html#example-usage) procedure using a KMS key of your choice. If encrypted with specific encryption_context please set that variable. | string | - | yes |
 | kms_key_arn | arn of the KMS key you used to encrypt the hec_token | string | - | yes |
 | encryption_context | aws_kms_secrets encryption context | map | `{}` | no |
 | hec_url | Splunk Kinesis URL for submitting CloudWatch logs to splunk | string | - | yes |
@@ -47,7 +48,7 @@ module "kinesis_firehose" {
 | tags | Map of tags to put on the resource | map | `null` | no |
 | cloudwatch_log_retention | Length in days to keep CloudWatch logs of Kinesis Firehose | integer | `30` | no |
 | log_stream_name | Name of the CloudWatch log stream for Kinesis Firehose CloudWatch log group | string | `SplunkDelivery` | no |
-| s3_bucket_name  | Name of the s3 bucket Kinesis Firehose uses for backups | string | `kinesis-firehose-to-splunk` | no |
+| s3_bucket_name  | Name of the s3 bucket Kinesis Firehose uses for backups | string | `kinesis-firehose-to-splunk` | yes |
 | s3_compression_format | The compression format for what the Kinesis Firehose puts in the s3 bucket | string | `GZIP` | no |
 | kinesis_firehose_lambda_role_name | Name of IAM Role for Lambda function that transforms CloudWatch data for Kinesis Firehose into Splunk compatible format | string | `KinesisFirehoseToLambaRole` | no |
 | lambda_iam_policy_name | Name of the IAM policy that is attached to the IAM Role for the lambda transform function | string | `Kinesis-Firehose-to-Splunk-Policy` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,8 +64,8 @@ resource "aws_s3_bucket" "kinesis_firehose_s3_bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "kinesis_firehose_s3_bucket" {
-  count  = "${var.s3_bucket_block_public_access_enabled}"
-  bucket = "${aws_s3_bucket.kinesis_firehose_s3_bucket.id}"
+  count  = var.s3_bucket_block_public_access_enabled
+  bucket = aws_s3_bucket.kinesis_firehose_s3_bucket.id
 
   block_public_acls       = true
   block_public_policy     = true

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,16 @@ resource "aws_s3_bucket" "kinesis_firehose_s3_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "kinesis_firehose_s3_bucket" {
+  count  = "${var.s3_bucket_block_public_access_enabled}"
+  bucket = "${aws_s3_bucket.kinesis_firehose_s3_bucket.id}"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Cloudwatch logging group for Kinesis Firehose
 resource "aws_cloudwatch_log_group" "kinesis_logs" {
   name              = "/aws/kinesisfirehose/${var.firehose_name}"

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,6 @@ resource "aws_kinesis_firehose_delivery_stream" "kinesis_firehose" {
 # S3 Bucket for Kinesis Firehose s3_backup_mode
 resource "aws_s3_bucket" "kinesis_firehose_s3_bucket" {
   bucket = var.s3_bucket_name
-  region = var.region
   acl    = "private"
 
   server_side_encryption_configuration {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "aws" {
-  version = ">= 2.7.0, <= 3.11.0"
+  version = ">= 2.7.0"
 
   region = var.region
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 3.0, <= 3.11.0"
+  version = ">= 2.7.0, <= 3.11.0"
 
   region = var.region
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = ">= 3.0, <= 3.11.0"
 
   region = var.region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,11 @@ variable "s3_bucket_name" {
   default     = "kinesis-firehose-to-splunk"
 }
 
+variable "s3_bucket_block_public_access_enabled" {
+  description = "Set to 1 if you would like to add block public access settings for the s3 bucket Kinesis Firehose uses for backups"
+  default     = 0
+}
+
 variable "encryption_context" {
   description = "aws_kms_secrets encryption context"
   type        = map(string)


### PR DESCRIPTION
Hello, first of all very much thanks for making and publishing this module, you saved me much time.

I adjusted the module so that it can support TF 13.x and the AWS provider 3.11.  From my testing, this has spun up all resources and I am seeing logs flow into my splunk instance.

I also added the aws_s3_bucket_public_access_block option (defaulted to false or 0) as we like to have it enabled on all buckets.  It prevents someone from making an object within the S3 bucket public in a private S3 bucket.

```
[terragrunt] 2020/10/22 15:19:18 Running command: terraform version
Terraform v0.13.3
+ provider registry.terraform.io/hashicorp/archive v2.0.0
+ provider registry.terraform.io/hashicorp/aws v3.11.0

Your version of Terraform is out of date! The latest version
is 0.13.5. You can update by downloading from https://www.terraform.io/downloads.html
```

