### PR TITLE
fix(provider):Move AWS provider to versions.tf, fix typo.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -287,7 +287,7 @@ resource "aws_iam_policy" "kinesis_firehose_iam_policy" {
   policy = data.aws_iam_policy_document.kinesis_firehose_policy_document.json
 }
 
-resource "aws_iam_role_policy_attachment" "kenisis_fh_role_attachment" {
+resource "aws_iam_role_policy_attachment" "kinesis_fh_role_attachment" {
   role       = aws_iam_role.kinesis_firehose.name
   policy_arn = aws_iam_policy.kinesis_firehose_iam_policy.arn
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,3 @@
 terraform {
   required_version = ">= 0.12.0"
 }
-
-provider "aws" {
-  version = ">= 2.7.0"
-
-  region = var.region
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.7.0"
+      region  = var.region
+    }
+  }
+}


### PR DESCRIPTION
I notice that I cannot delete resources created by this module by just commenting or deleting the module block.  The error I receive is:

```
Error: Provider configuration not present

To work with
module.splunk_firehose_flow_logs.data.aws_iam_policy_document.lambda_policy_doc
its original provider configuration at
module.splunk_firehose_flow_logs.provider["registry.terraform.io/hashicorp/aws"]
is required, but it has been removed. This occurs when a provider
configuration is removed while objects created by that provider still exist in
the state. Re-add the provider configuration to destroy
module.splunk_firehose_flow_logs.data.aws_iam_policy_document.lambda_policy_doc,
after which you can remove the provider configuration again.
```

This means that I either have to manually delete each of the 15 resources that each use of this module creates, or destroy them.  Either option is not ideal.

This could also make this module compatible with for_each, which would be super helpful for iteration.  Currently, attempting to use for_each gives the following error:

```
Error: Module does not support for_each
  on splunk.tf line 98, in module "splunk_firehose_apps":
  98:   for_each                     = var.splunk_firehose_apps
Module "splunk_firehose_apps" cannot be used with for_each because it contains
a nested provider configuration for "aws", at
.terraform/modules/splunk_firehose_apps/terraform.tf:5,10-15.
This module can be made compatible with for_each by changing it to receive all
of its provider configurations from the calling module, by using the
"providers" argument in the calling module block.
```