### PR TITLE
feat: expose lambda_function_environment_variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -276,6 +276,10 @@ resource "aws_lambda_function" "firehose_lambda_transform" {
   timeout                        = var.lambda_function_timeout
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
 
+  environment  {
+    variables = var.lambda_function_environment_variables
+  }  
+
   dynamic "tracing_config" {
     for_each = var.lambda_tracing_config == null ? [] : [1]
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -143,6 +143,11 @@ variable "lambda_function_timeout" {
   default     = 180
 }
 
+variable "lambda_function_environment_variables" {
+    description = "Environment variables for the lambda function"
+    default = { }
+}
+
 variable "lambda_iam_policy_name" {
   description = "Name of the IAM policy that is attached to the IAM Role for the lambda transform function"
   type        = string


### PR DESCRIPTION
A simple PR to expose environment variables: 

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#environment