### PR TITLE
Enable Cloudwatch Logs Access From Multiple Regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ As of v7.0.0, there are two additional options available to pass in the HEC toke
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_hec_url"></a> [hec\_url](#input\_hec\_url) | Splunk Kinesis URL for submitting CloudWatch logs to splunk | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The region of AWS you want to work in, such as us-west-2 or us-east-1 | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region of AWS you want to work in, such as us-west-2 or us-east-1 | `string` | n/a | no |
+| <a name="input_cloudwatch_log_regions"></a> [region](#input\_cloudwatch_log_regions) | List of regions to allow CloudWatch logs to be shipped from. Set in Kinesis Firehose role's trust polucy | `list(string)` | n/a | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Name of the s3 bucket Kinesis Firehose uses for backups | `string` | n/a | yes |
 | <a name="input_arn_cloudwatch_logs_to_ship"></a> [arn\_cloudwatch\_logs\_to\_ship](#input\_arn\_cloudwatch\_logs\_to\_ship) | arn of the CloudWatch Log Group that you want to ship to Splunk. | `string` | `null` | no |
 | <a name="input_aws_s3_bucket_versioning"></a> [aws\_s3\_bucket\_versioning](#input\_aws\_s3\_bucket\_versioning) | Versioning state of the bucket. Valid values: Enabled, Suspended, or Disabled. Disabled should only be used when creating or importing resources that correspond to unversioned S3 buckets. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -403,24 +403,22 @@ resource "aws_iam_role_policy_attachment" "kinesis_fh_role_attachment" {
   policy_arn = aws_iam_policy.kinesis_firehose_iam_policy.arn
 }
 
+data "aws_iam_policy_document" "cloudwatch_to_firehose_trust_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = [for region in var.cloudwatch_log_regions : "logs.${region}.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role" "cloudwatch_to_firehose_trust" {
   name        = var.cloudwatch_to_firehose_trust_iam_role_name
-  description = "Role for CloudWatch Log Group subscription"
-
-  assume_role_policy = <<ROLE
-{
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "logs.${var.region}.amazonaws.com"
-      }
-    }
-  ],
-  "Version": "2012-10-17"
-}
-ROLE
+  description = "Role for CloudWatch Log Group subscriptions"
+  
+  assume_role_policy = "${data.aws_iam_policy_document.cloudwatch_to_firehose_trust_assume_policy.json}"
 }
 
 data "aws_iam_policy_document" "cloudwatch_to_fh_access_policy" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   lambda_function_source_file = var.local_lambda_file != null ? var.local_lambda_file : "${path.module}/files/kinesis-firehose-cloudwatch-logs-processor.js"
   lambda_function_handler     = var.local_lambda_file_handler != null ? var.local_lambda_file_handler : "kinesis-firehose-cloudwatch-logs-processor.handler"
+  cloudwatch_log_regions = var.region == null ? var.cloudwatch_log_regions : [var.region]
 }
 
 # Kenisis firehose stream
@@ -409,7 +410,7 @@ data "aws_iam_policy_document" "cloudwatch_to_firehose_trust_assume_policy" {
     effect = "Allow"
     principals {
       type        = "Service"
-      identifiers = [for region in var.cloudwatch_log_regions : "logs.${region}.amazonaws.com"]
+      identifiers = [for region in local.cloudwatch_log_regions : "logs.${region}.amazonaws.com"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,13 @@
 variable "region" {
   description = "The region of AWS you want to work in, such as us-west-2 or us-east-1 (deprecated: use cloudwatch_log_regions instead)"
   type        = string
+  default = null
 }
 
 variable "cloudwatch_log_regions" {
   description = "List of regions to allow CloudWatch logs to be shipped from. Set in Kinesis Firehose role's trust polucy"
   type        = list(string)
-  default = [ var.region ]
+  default = [ ]
 }
 
 variable "hec_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "region" {
-  description = "The region of AWS you want to work in, such as us-west-2 or us-east-1"
+  description = "The region of AWS you want to work in, such as us-west-2 or us-east-1 (deprecated: use cloudwatch_log_regions instead)"
   type        = string
+}
+
+variable "cloudwatch_log_regions" {
+  description = "List of regions to allow CloudWatch logs to be shipped from. Set in Kinesis Firehose role's trust polucy"
+  type        = list(string)
+  default = [ var.region ]
 }
 
 variable "hec_url" {


### PR DESCRIPTION
- We would like to create CloudWatch Log Subscription filters in multiple regions without deploying module in multiple regions. This requires adjusting Kinesis IAM Role policy to allow `logs.REGION.amazonaws.com` Service to assume the role.
- var.region is only used to set trust relationship for the Kinesis Firehose IAM Role.
- This PR introduced a extra variable (`cloudwatch_log_regions`) of type list to enable access to multiple regions.
- Not removing `var.region` to prevent breaking change. `cloudwatch_log_regions` will default to var.region as list with single entry if `cloudwatch_log_regions` is not supplied.
- Tested changes successfully.
