### PR TITLE
fix: No need to invoke .promise() since the upgrade to aws-sdk v3  #36

### DIFF
--- a/files/kinesis-firehose-cloudwatch-logs-processor.js
+++ b/files/kinesis-firehose-cloudwatch-logs-processor.js
@@ -128,7 +128,7 @@ async function putRecordsBase (
       [streamNameArgName]: streamName,
       Records: records
     }
-    const response = await client[methodName](args).promise()
+    const response = await client[methodName](args)
     const errCodes = []
     for (let i = 0; i < response[failureDetailsKey].length; i++) {
       const errCode = response[failureDetailsKey][i].ErrorCode


### PR DESCRIPTION
fix: No need to invoke .promise() since the upgrade to aws-sdk v3  #36