### PR TITLE
use current aws partition for CW log arn instead of hard coding

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,5 @@
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
       ]
 
       resources = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${statement.value}:*"
+        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${statement.value}:*"
       ]
 
       effect = "Allow"
@@ -233,7 +233,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
       ]
 
       resources = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${statement.value}:*"
+        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${statement.value}:*"
       ]
 
       effect = "Allow"


### PR DESCRIPTION
`lambda_policy_doc` IAM policy was not working in GovCloud because of fixed "aws" partition. 