### PR TITLE
fix-log-group

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.3.0, < 3.0.0"
   hashes = [
     "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
+    "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
     "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
     "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
     "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 5.0.0, < 6.0.0"
   hashes = [
     "h1:LeGaxHyCnTpZdrhVCSJwDx91JcPWXlf4Rt4mnlF34Gs=",
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
     "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
     "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
     "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
 
       # Handle `var.name_cloudwatch_logs_to_ship` (string, list, or null)
       var.name_cloudwatch_logs_to_ship != null ? (
-        can(regex("^.*$", var.name_cloudwatch_logs_to_ship)) ?
+        type(var.name_cloudwatch_logs_to_ship) == string ?
         tolist(["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name_cloudwatch_logs_to_ship}:*"]) :
         tolist([for log in var.name_cloudwatch_logs_to_ship :
           "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
@@ -240,24 +240,6 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
     effect = "Allow"
   }
 }
-
-
-  # CloudWatch permissions for logging
-  statement {
-    actions = [
-      "logs:PutLogEvents",
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream"
-    ]
-    resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
-    ]
-    effect = "Allow"
-  }
-}
-
-
-
 
 resource "aws_iam_policy" "lambda_transform_policy" {
   name   = var.lambda_iam_policy_name

--- a/main.tf
+++ b/main.tf
@@ -242,6 +242,21 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
 }
 
 
+  # CloudWatch permissions for logging
+  statement {
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream"
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    ]
+    effect = "Allow"
+  }
+}
+
+
 
 
 resource "aws_iam_policy" "lambda_transform_policy" {

--- a/main.tf
+++ b/main.tf
@@ -202,19 +202,19 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
     resources = concat(
       # Handle `var.arn_cloudwatch_logs_to_ship` (single string or null)
       var.arn_cloudwatch_logs_to_ship != null ? [var.arn_cloudwatch_logs_to_ship] : [],
-      
+
       # Handle `var.cloudwatch_log_group_names_to_ship` (list or null)
-      toset(var.cloudwatch_log_group_names_to_ship) != null ? tolist([for log in toset(var.cloudwatch_log_group_names_to_ship) :
+      var.cloudwatch_log_group_names_to_ship != null ? tolist([for log in toset(var.cloudwatch_log_group_names_to_ship) :
         "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
       ]) : [],
-      
+
       # Handle `var.name_cloudwatch_logs_to_ship` (string, list, or null)
-      var.name_cloudwatch_logs_to_ship != null ? tolist(
-        type(var.name_cloudwatch_logs_to_ship) == string ? 
-        [var.name_cloudwatch_logs_to_ship] : 
-        [for log in var.name_cloudwatch_logs_to_ship :
+      var.name_cloudwatch_logs_to_ship != null ? (
+        type(var.name_cloudwatch_logs_to_ship) == string ?
+        tolist(["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name_cloudwatch_logs_to_ship}:*"]) :
+        tolist([for log in var.name_cloudwatch_logs_to_ship :
           "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
-        ]
+        ])
       ) : []
     )
     effect = "Allow"
@@ -240,6 +240,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
     effect = "Allow"
   }
 }
+
 
 
 resource "aws_iam_policy" "lambda_transform_policy" {

--- a/main.tf
+++ b/main.tf
@@ -200,13 +200,22 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
   statement {
     actions = ["logs:GetLogEvents"]
     resources = concat(
+      # Handle `var.arn_cloudwatch_logs_to_ship` (single string or null)
       var.arn_cloudwatch_logs_to_ship != null ? [var.arn_cloudwatch_logs_to_ship] : [],
+      
+      # Handle `var.cloudwatch_log_group_names_to_ship` (list or null)
       toset(var.cloudwatch_log_group_names_to_ship) != null ? tolist([for log in toset(var.cloudwatch_log_group_names_to_ship) :
         "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
       ]) : [],
-      var.name_cloudwatch_logs_to_ship != null ? tolist([for log in var.name_cloudwatch_logs_to_ship :
-        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
-      ]) : []
+      
+      # Handle `var.name_cloudwatch_logs_to_ship` (string, list, or null)
+      var.name_cloudwatch_logs_to_ship != null ? tolist(
+        type(var.name_cloudwatch_logs_to_ship) == string ? 
+        [var.name_cloudwatch_logs_to_ship] : 
+        [for log in var.name_cloudwatch_logs_to_ship :
+          "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
+        ]
+      ) : []
     )
     effect = "Allow"
   }

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
 
       # Handle `var.name_cloudwatch_logs_to_ship` (string, list, or null)
       var.name_cloudwatch_logs_to_ship != null ? (
-        type(var.name_cloudwatch_logs_to_ship) == string ?
+        can(regex("^.*$", var.name_cloudwatch_logs_to_ship)) ?
         tolist(["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name_cloudwatch_logs_to_ship}:*"]) :
         tolist([for log in var.name_cloudwatch_logs_to_ship :
           "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
 
       # Handle `var.name_cloudwatch_logs_to_ship` (string, list, or null)
       var.name_cloudwatch_logs_to_ship != null ? (
-        type(var.name_cloudwatch_logs_to_ship) == string ?
+        can(regex("^.*$", var.name_cloudwatch_logs_to_ship)) ?
         tolist(["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name_cloudwatch_logs_to_ship}:*"]) :
         tolist([for log in var.name_cloudwatch_logs_to_ship :
           "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${log}:*"
@@ -240,6 +240,7 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
     effect = "Allow"
   }
 }
+
 
 
 


### PR DESCRIPTION
Problem
=======
Checks if var.name_cloudwatch_logs_to_ship is not null.
Uses the can() function with regex() to determine if the value is a string (a single log group name).
If it's a string, it wraps it in a list with the corresponding ARN format.
If it's a list, it iterates over the items using a for loop to construct the ARNs for each log group.
If var.name_cloudwatch_logs_to_ship is null, it results in an empty list.

Approach 
==============

This handles cases where var.name_cloudwatch_logs_to_ship could be a string, a list, or null.
It explicitly distinguishes between these cases using can().
