### PR TITLE
feat: add conditional S3 public access block resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,17 @@ resource "aws_s3_bucket_ownership_controls" "kinesis_firehose_s3_bucket" {
   }
 }
 
+# NOTE: S3 Public Access Block configuration - created conditionally based on variable
+# This resource blocks all public access to the S3 bucket when enabled for enhanced security
+resource "aws_s3_bucket_public_access_block" "kinesis_firehose_s3_bucket" {
+  count  = var.s3_bucket_block_public_access_enabled == 1 ? 1 : 0
+  bucket = aws_s3_bucket.kinesis_firehose_s3_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "kinesis_firehose_s3_bucket" {
   bucket = aws_s3_bucket.kinesis_firehose_s3_bucket.bucket


### PR DESCRIPTION
## Summary
This PR adds the missing `aws_s3_bucket_public_access_block` resource that was referenced by the existing `s3_bucket_block_public_access_enabled` variable but not actually implemented.

## Changes
- ✅ Add `aws_s3_bucket_public_access_block` resource with conditional creation
- ✅ Enable all public access restrictions when activated
- ✅ Add English comments explaining security configuration
- ✅ Maintain backward compatibility (default behavior unchanged)

## Files Modified
- [main.tf](cci:7://file:///c:/Users/PC/OneDrive/%EB%B0%94%ED%83%95%20%ED%99%94%EB%A9%B4/disney/terraform-aws-kinesis-firehose-splunk/main.tf:0:0-0:0): Added conditional S3 public access block resource

## Security Enhancement
When `s3_bucket_block_public_access_enabled = 1`, this resource will:
- Block public ACLs (`block_public_acls = true`)
- Block public bucket policies (`block_public_policy = true`) 
- Ignore public ACLs (`ignore_public_acls = true`)
- Restrict public bucket access (`restrict_public_buckets = true`)

## Testing
- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [x] Backward compatible (existing deployments unaffected)
- [x] Resource created only when variable is set to 1

## Usage
```hcl
module "kinesis_firehose" {
  source = "disney/kinesis-firehose-splunk/aws"
  
  s3_bucket_block_public_access_enabled = 1  # Enable public access blocking
  # ... other variables
}