### PR TITLE
feat: Support direct HEC token fetching from AWS Secrets Manager

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.3.0, < 3.0.0"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 6.11.0, < 7.0.0"
   hashes = [
     "h1:Ao401IE4NzgRUKOKpAus0Ul47QgDNCbFIyXRHUEI4A8=",
+    "h1:zZ8v7mG/NqTNdXVNJL/hvqfg9CqnFXE4krBPnK/zxWI=",
     "zh:02da12526aa5abdb26c41f204c159ee0ef26a735534e09024e00870cda45a058",
     "zh:1a9205ee7a09b152e402df6c5a4479bef4f518ec39d097922556dd47157ff62f",
     "zh:43cb5143f0c6cc2b34923b0dc8db60d25452336bd6bceafc3f2d9812c72ed1b9",
@@ -41,5 +43,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:bbc578faeeb15ed8c0853d382f73260cc95a8bcf14a5455a0ed4ca61c243970c",
     "zh:cb3892c781b3f928b0c42261ae8c03cef8ac0cbbdddf0ab0637eea9f49482f80",
     "zh:e562cd17bb3fb318b5ba7a006c461fd2a6703c8f9862a7a6494cf304922f4da0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ As of v7.0.0, there are two additional options available to pass in the HEC toke
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.1 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.11.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 
 ### Modules
 
@@ -94,6 +95,7 @@ As of v7.0.0, there are two additional options available to pass in the HEC toke
 | [aws_s3_bucket_public_access_block.kinesis_firehose_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.kinesis_firehose_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.kinesis_firehose_s3_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [null_resource.hec_token_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [archive_file.lambda_function](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cloudwatch_to_fh_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -128,7 +130,7 @@ As of v7.0.0, there are two additional options available to pass in the HEC toke
 | <a name="input_firehose_server_side_encryption_key_type"></a> [firehose\_server\_side\_encryption\_key\_type](#input\_firehose\_server\_side\_encryption\_key\_type) | Type of SSE key to be used for encrypting the Firehose. Valid values are `AWS_OWNED_CMK` and `CUSTOMER_MANAGED_CMK` | `string` | `null` | no |
 | <a name="input_hec_acknowledgment_timeout"></a> [hec\_acknowledgment\_timeout](#input\_hec\_acknowledgment\_timeout) | The amount of time, in seconds between 180 and 600, that Kinesis Firehose waits to receive an acknowledgment from Splunk after it sends it data. | `number` | `300` | no |
 | <a name="input_hec_endpoint_type"></a> [hec\_endpoint\_type](#input\_hec\_endpoint\_type) | Splunk HEC endpoint type; `Raw` or `Event` | `string` | `"Raw"` | no |
-| <a name="input_hec_token"></a> [hec\_token](#input\_hec\_token) | Splunk security token needed to submit data to Splunk. Required if var.self\_managed\_hec\_token is not specified. | `string` | `null` | no |
+| <a name="input_hec_token"></a> [hec\_token](#input\_hec\_token) | Splunk security token needed to submit data to Splunk. Required if var.self\_managed\_hec\_token and var.self\_managed\_hec\_token\_secrets\_manager\_secret\_arn are not specified. | `string` | `null` | no |
 | <a name="input_kinesis_firehose_buffer"></a> [kinesis\_firehose\_buffer](#input\_kinesis\_firehose\_buffer) | https://www.terraform.io/docs/providers/aws/r/kinesis_firehose_delivery_stream.html#buffer_size | `number` | `5` | no |
 | <a name="input_kinesis_firehose_buffer_interval"></a> [kinesis\_firehose\_buffer\_interval](#input\_kinesis\_firehose\_buffer\_interval) | Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination | `number` | `300` | no |
 | <a name="input_kinesis_firehose_iam_policy_name"></a> [kinesis\_firehose\_iam\_policy\_name](#input\_kinesis\_firehose\_iam\_policy\_name) | Name of the IAM Policy attached to IAM Role for the Kinesis Firehose | `string` | `"KinesisFirehose-Policy"` | no |
@@ -164,7 +166,8 @@ As of v7.0.0, there are two additional options available to pass in the HEC toke
 | <a name="input_s3_bucket_server_side_encryption_kms_master_key_id"></a> [s3\_bucket\_server\_side\_encryption\_kms\_master\_key\_id](#input\_s3\_bucket\_server\_side\_encryption\_kms\_master\_key\_id) | AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse\_algorithm is aws:kms | `string` | `null` | no |
 | <a name="input_s3_compression_format"></a> [s3\_compression\_format](#input\_s3\_compression\_format) | The compression format for what the Kinesis Firehose puts in the s3 bucket | `string` | `"GZIP"` | no |
 | <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | Optional prefix (a slash after the prefix will show up as a folder in the s3 bucket).  The YYYY/MM/DD/HH time format prefix is automatically used for delivered S3 files. | `string` | `"kinesis-firehose/"` | no |
-| <a name="input_self_managed_hec_token"></a> [self\_managed\_hec\_token](#input\_self\_managed\_hec\_token) | This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to use a different tool than SSM or KMS encryption in their code base to encrypt it. Required if var.hec\_token is not specified. | `string` | `null` | no |
+| <a name="input_self_managed_hec_token"></a> [self\_managed\_hec\_token](#input\_self\_managed\_hec\_token) | This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to use a different tool than SSM or KMS encryption in their code base to encrypt it. Required if var.hec\_token and var.self\_managed\_hec\_token\_secrets\_manager\_secret\_arn are not specified. | `string` | `null` | no |
+| <a name="input_self_managed_hec_token_secrets_manager_secret_arn"></a> [self\_managed\_hec\_token\_secrets\_manager\_secret\_arn](#input\_self\_managed\_hec\_token\_secrets\_manager\_secret\_arn) | This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to increase security by not passing the HEC token directly, but instead they want to let Firehose fetch it from AWS SM. Required if var.hec\_token and var.self\_managed\_hec\_token are not specified. | `string` | `null` | no |
 | <a name="input_subscription_filter_pattern"></a> [subscription\_filter\_pattern](#input\_subscription\_filter\_pattern) | Filter pattern for the CloudWatch Log Group subscription to the Kinesis Firehose. See [this](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) for filter pattern info. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to put on the resource | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,15 @@ resource "aws_kinesis_firehose_delivery_stream" "kinesis_firehose" {
     s3_backup_mode             = var.s3_backup_mode
     retry_duration             = var.kinesis_firehose_retry_duration
 
+    dynamic "secrets_manager_configuration" {
+      for_each = var.self_managed_hec_token_secrets_manager_secret_arn != null ? [1] : []
+      content {
+        enabled    = var.self_managed_hec_token_secrets_manager_secret_arn != null ? true : false
+        secret_arn = var.self_managed_hec_token_secrets_manager_secret_arn
+        role_arn   = aws_iam_role.kinesis_firehose.arn
+      }
+    }
+
     s3_configuration {
       role_arn           = aws_iam_role.kinesis_firehose.arn
       prefix             = var.s3_prefix
@@ -384,6 +393,21 @@ data "aws_iam_policy_document" "kinesis_firehose_policy_document" {
       aws_cloudwatch_log_group.kinesis_logs.arn,
       "${aws_cloudwatch_log_group.kinesis_logs.arn}:*",
     ]
+  }
+
+  dynamic "statement" {
+    for_each = var.self_managed_hec_token_secrets_manager_secret_arn != null ? [1] : []
+    content {
+      actions = [
+        "secretsmanager:GetSecretValue",
+      ]
+
+      effect = "Allow"
+
+      resources = [
+        var.self_managed_hec_token_secrets_manager_secret_arn,
+      ]
+    }
   }
 }
 

--- a/validations.tf
+++ b/validations.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "hec_token_validation" {
+  lifecycle {
+    precondition {
+      condition     = length(compact([var.hec_token, var.self_managed_hec_token, var.self_managed_hec_token_secrets_manager_secret_arn])) == 1
+      error_message = "Only one of var.hec_token, var.self_managed_hec_token and var.self_managed_hec_token_secrets_manager_arn must be defined."
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -341,6 +341,12 @@ variable "self_managed_hec_token" {
   default     = null
 }
 
+variable "self_managed_hec_token_secrets_manager_secret_arn" {
+  description = "This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to use a different tool than SSM or KMS encryption in their code base to encrypt it. Required if var.hec_token is not specified."
+  type        = string
+  default     = null
+}
+
 variable "lambda_processing_buffer_size_in_mb" {
   description = "Lambda processing buffer size in mb."
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,7 @@ variable "hec_url" {
 variable "hec_token" {
   description = "Splunk security token needed to submit data to Splunk. Required if var.self_managed_hec_token and var.self_managed_hec_token_secrets_manager_secret_arn are not specified."
   type        = string
+  sensitive   = true
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "hec_url" {
 }
 
 variable "hec_token" {
-  description = "Splunk security token needed to submit data to Splunk. Required if var.self_managed_hec_token is not specified."
+  description = "Splunk security token needed to submit data to Splunk. Required if var.self_managed_hec_token and var.self_managed_hec_token_secrets_manager_secret_arn are not specified."
   type        = string
   default     = null
 }
@@ -335,14 +335,14 @@ variable "object_lock_configuration_years" {
 }
 
 variable "self_managed_hec_token" {
-  description = "This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to use a different tool than SSM or KMS encryption in their code base to encrypt it. Required if var.hec_token is not specified."
+  description = "This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to use a different tool than SSM or KMS encryption in their code base to encrypt it. Required if var.hec_token and var.self_managed_hec_token_secrets_manager_secret_arn are not specified."
   type        = string
   sensitive   = true
   default     = null
 }
 
 variable "self_managed_hec_token_secrets_manager_secret_arn" {
-  description = "This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to use a different tool than SSM or KMS encryption in their code base to encrypt it. Required if var.hec_token is not specified."
+  description = "This variable allows for the user to have additional flexibility in how they pass in the HEC token. Perhaps they want to increase security by not passing the HEC token directly, but instead they want to let Firehose fetch it from AWS SM. Required if var.hec_token and var.self_managed_hec_token are not specified."
   type        = string
   default     = null
 }


### PR DESCRIPTION
- **support for `secrets_manager_configuration {}` block** in `aws_kinesis_firehose_delivery_stream` resource. This should provide a more secure way of passing the Splunk HEC token.
- On top of that, there is a **new  variable validation**, so that only one of the HEC token variables is used during the module call.
- The `var.hec_token` is **marked as sensitive**.
